### PR TITLE
Bugfix FXIOS-14274 #30901 [Swift 6 Migration] Fix WebServer warnings

### DIFF
--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -72,7 +72,7 @@ typedef GCDWebServerResponse* _Nullable (^GCDWebServerProcessBlock)(__kindof GCD
  *  It's however recommended to return a GCDWebServerErrorResponse on error so more
  *  useful information can be returned to the client.
  */
-typedef void (^GCDWebServerCompletionBlock)(GCDWebServerResponse* _Nullable response);
+typedef void (^GCD_SWIFT_SENDABLE GCDWebServerCompletionBlock)(GCDWebServerResponse* _Nullable response);
 typedef void (^GCDWebServerAsyncProcessBlock)(__kindof GCDWebServerRequest* request, GCDWebServerCompletionBlock completionBlock);
 
 /**

--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -32,6 +32,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if __has_attribute(swift_attr)
+#define GCD_SWIFT_SENDABLE __attribute__((swift_attr("@Sendable")))
+#else
+#define GCD_SWIFT_SENDABLE
+#endif
+
 /**
  *  The GCDWebServerMatchBlock is called for every handler added to the
  *  GCDWebServer whenever a new HTTP request has started (i.e. HTTP headers have

--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -34,10 +34,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if __has_attribute(swift_attr)
 #define GCD_SWIFT_SENDABLE __attribute__((swift_attr("@Sendable")))
-#define GCD_SWIFT_UNCHECKED_SENDABLE __attribute__((swift_attr("@unchecked Sendable")))
 #else
 #define GCD_SWIFT_SENDABLE
-#define GCD_SWIFT_UNCHECKED_SENDABLE
 #endif
 
 /**
@@ -50,7 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  GCDWebServerRequest instance created with the same basic info.
  *  Otherwise, it simply returns nil.
  */
-typedef GCDWebServerRequest* GCD_SWIFT_UNCHECKED_SENDABLE _Nullable (^GCDWebServerMatchBlock)(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery);
+typedef GCDWebServerRequest* _Nullable (^GCDWebServerMatchBlock)(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery);
 
 /**
  *  The GCDWebServerProcessBlock is called after the HTTP request has been fully

--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -50,9 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  GCDWebServerRequest instance created with the same basic info.
  *  Otherwise, it simply returns nil.
  */
-
-GCD_SWIFT_UNCHECKED_SENDABLE
-typedef GCDWebServerRequest* _Nullable (^GCDWebServerMatchBlock)(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery);
+typedef GCDWebServerRequest* GCD_SWIFT_UNCHECKED_SENDABLE _Nullable (^GCDWebServerMatchBlock)(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery);
 
 /**
  *  The GCDWebServerProcessBlock is called after the HTTP request has been fully

--- a/GCDWebServer/Core/GCDWebServer.h
+++ b/GCDWebServer/Core/GCDWebServer.h
@@ -34,8 +34,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if __has_attribute(swift_attr)
 #define GCD_SWIFT_SENDABLE __attribute__((swift_attr("@Sendable")))
+#define GCD_SWIFT_UNCHECKED_SENDABLE __attribute__((swift_attr("@unchecked Sendable")))
 #else
 #define GCD_SWIFT_SENDABLE
+#define GCD_SWIFT_UNCHECKED_SENDABLE
 #endif
 
 /**
@@ -48,6 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  GCDWebServerRequest instance created with the same basic info.
  *  Otherwise, it simply returns nil.
  */
+
+GCD_SWIFT_UNCHECKED_SENDABLE
 typedef GCDWebServerRequest* _Nullable (^GCDWebServerMatchBlock)(NSString* requestMethod, NSURL* requestURL, NSDictionary<NSString*, NSString*>* requestHeaders, NSString* urlPath, NSDictionary<NSString*, NSString*>* urlQuery);
 
 /**

--- a/GCDWebServer/Core/GCDWebServerRequest.h
+++ b/GCDWebServer/Core/GCDWebServerRequest.h
@@ -93,7 +93,8 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
  *
  *  @warning GCDWebServerRequest instances can be created and used on any GCD thread.
  */
-@interface GCDWebServerRequest GCD_SWIFT_UNCHECKED_SENDABLE : NSObject <GCDWebServerBodyWriter>
+GCD_SWIFT_UNCHECKED_SENDABLE
+@interface GCDWebServerRequest : NSObject <GCDWebServerBodyWriter>
 
 /**
  *  Returns the HTTP method for the request.

--- a/GCDWebServer/Core/GCDWebServerRequest.h
+++ b/GCDWebServer/Core/GCDWebServerRequest.h
@@ -29,6 +29,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if __has_attribute(swift_attr)
+#define GCD_SWIFT_UNCHECKED_SENDABLE __attribute__((swift_attr("@unchecked Sendable")))
+#else
+#define GCD_SWIFT_UNCHECKED_SENDABLE
+#endif
+
 /**
  *  Attribute key to retrieve an NSArray containing NSStrings from a GCDWebServerRequest
  *  with the contents of any regular expression captures done on the request path.
@@ -87,6 +93,7 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
  *
  *  @warning GCDWebServerRequest instances can be created and used on any GCD thread.
  */
+GCD_SWIFT_UNCHECKED_SENDABLE
 @interface GCDWebServerRequest : NSObject <GCDWebServerBodyWriter>
 
 /**

--- a/GCDWebServer/Core/GCDWebServerRequest.h
+++ b/GCDWebServer/Core/GCDWebServerRequest.h
@@ -93,8 +93,7 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
  *
  *  @warning GCDWebServerRequest instances can be created and used on any GCD thread.
  */
-GCD_SWIFT_UNCHECKED_SENDABLE
-@interface GCDWebServerRequest : NSObject <GCDWebServerBodyWriter>
+@interface GCDWebServerRequest GCD_SWIFT_UNCHECKED_SENDABLE : NSObject <GCDWebServerBodyWriter>
 
 /**
  *  Returns the HTTP method for the request.

--- a/GCDWebServer/Core/GCDWebServerRequest.h
+++ b/GCDWebServer/Core/GCDWebServerRequest.h
@@ -29,12 +29,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#if __has_attribute(swift_attr)
-#define GCD_SWIFT_UNCHECKED_SENDABLE __attribute__((swift_attr("@unchecked Sendable")))
-#else
-#define GCD_SWIFT_UNCHECKED_SENDABLE
-#endif
-
 /**
  *  Attribute key to retrieve an NSArray containing NSStrings from a GCDWebServerRequest
  *  with the contents of any regular expression captures done on the request path.
@@ -93,7 +87,6 @@ extern NSString* const GCDWebServerRequestAttribute_RegexCaptures;
  *
  *  @warning GCDWebServerRequest instances can be created and used on any GCD thread.
  */
-GCD_SWIFT_UNCHECKED_SENDABLE
 @interface GCDWebServerRequest : NSObject <GCDWebServerBodyWriter>
 
 /**


### PR DESCRIPTION
## :scroll: Tickets
[Jira ticket](https://mozilla-hub.atlassian.net/browse/FXIOS-14274)
[Github issue](https://github.com/mozilla-mobile/firefox-ios/issues/30901)

## :bulb: Description
Fix `WebServer` warnings. This work makes the `GCDWebServerCompletionBlock` `Sendable`. I tried making the `GCDWebServerRequest` interface `@unchecked Sendable` so we didn't have to add the [`@preconcurrency import`](https://github.com/mozilla-mobile/firefox-ios/pull/31380) inside the Client but that didn't work (had warnings on each attempt). So this is the solution for now, let me know if you see another attempt we can try